### PR TITLE
Switching registration to use dict.

### DIFF
--- a/src/footmav/__init__.py
+++ b/src/footmav/__init__.py
@@ -9,3 +9,5 @@ from footmav.operations.filter_objects import Filter
 from footmav.operations.aggregations import aggregate_by
 from footmav.operations.normalize import per_90
 from footmav.data_definitions.fbref import fbref_columns as fc
+from footmav.odm.fbref_data import FbRefData
+from footmav.odm.data import Data

--- a/src/footmav/data_definitions/base.py
+++ b/src/footmav/data_definitions/base.py
@@ -53,15 +53,6 @@ class DataAttribute:
 
         self._normalizable = normalizable
 
-        if next(
-            (
-                a
-                for a in RegisteredAttributeStore.get_registered_attributes()
-                if a.N == name and a != self
-            ),
-            None,
-        ):
-            raise ValueError(f"DataAttribute with name {name} already exists")
         RegisteredAttributeStore.register_attribute(self)
 
     def __str__(self) -> str:

--- a/src/footmav/data_definitions/derived.py
+++ b/src/footmav/data_definitions/derived.py
@@ -25,8 +25,8 @@ class DerivedDataAttribute(DataAttribute, abc.ABC):
         source: DataSource,
         recalculate_on_aggregation: bool = True,
     ):
-        super().__init__(name, data_type, agg_function, source)
         self._recalculate_on_aggregation = recalculate_on_aggregation
+        super().__init__(name, data_type, agg_function, source)
 
     @property
     def recalculate_on_aggregation(self) -> bool:
@@ -73,10 +73,10 @@ class FunctionDerivedDataAttribute(DerivedDataAttribute):
         agg_function: Optional[Union[Callable, str]] = None,
         recalculate_on_aggregation: bool = True,
     ):
+        self.function = function
         super().__init__(
             name, data_type, agg_function, source, recalculate_on_aggregation
         )
-        self.function = function
 
     def apply(self, data: pd.DataFrame) -> pd.Series:
         """Calculate the data attribute from the baseline data.

--- a/src/footmav/data_definitions/fbref/fbref_columns.py
+++ b/src/footmav/data_definitions/fbref/fbref_columns.py
@@ -200,13 +200,6 @@ NPXG = FloatDataAttribute("npxg", source=DataSource.FBREF)
 XA = FloatDataAttribute("xa", source=DataSource.FBREF)
 
 
-YEAR_FB_REF = IntDataAttribute(
-    "year",
-    rename_to="season",
-    agg_function="first",
-    source=DataSource.FBREF,
-)
-
 SHOTS_ON_TARGET_AGAINST = FloatDataAttribute(
     "shots_on_target_against", source=DataSource.FBREF
 )

--- a/test/data_definitions/test_base.py
+++ b/test/data_definitions/test_base.py
@@ -7,7 +7,7 @@ class TestDataAttribute:
     def test_init(self):
         with patch(
             "footmav.data_definitions.base.RegisteredAttributeStore._registered_attributes",
-            new=set(),
+            new=dict(),
         ):
 
             from footmav.data_definitions.base import (
@@ -32,7 +32,7 @@ class TestDataAttribute:
     def test_init_duplicate_fail(self):
         with patch(
             "footmav.data_definitions.base.RegisteredAttributeStore._registered_attributes",
-            new=set(),
+            new=dict(),
         ):
             from footmav.data_definitions.base import DataAttribute
             from footmav.data_definitions.data_sources import DataSource
@@ -61,7 +61,7 @@ class TestNativeDataAttribute:
     def test_init(self):
         with patch(
             "footmav.data_definitions.base.RegisteredAttributeStore._registered_attributes",
-            new=set(),
+            new=dict(),
         ):
             from footmav.data_definitions.base import NativeDataAttribute
             from footmav.data_definitions.data_sources import DataSource
@@ -83,7 +83,7 @@ class TestNativeDataAttribute:
     def test_n_with_rename(self):
         with patch(
             "footmav.data_definitions.base.RegisteredAttributeStore._registered_attributes",
-            new=set(),
+            new=dict(),
         ):
             from footmav.data_definitions.base import NativeDataAttribute
             from footmav.data_definitions.data_sources import DataSource
@@ -103,7 +103,7 @@ class TestNativeDataAttribute:
     def test_n_without_rename(self):
         with patch(
             "footmav.data_definitions.base.RegisteredAttributeStore._registered_attributes",
-            new=set(),
+            new=dict(),
         ):
             from footmav.data_definitions.base import NativeDataAttribute
             from footmav.data_definitions.data_sources import DataSource
@@ -122,7 +122,7 @@ class TestNativeDataAttribute:
     def test_user_transform_with_transform_function(self):
         with patch(
             "footmav.data_definitions.base.RegisteredAttributeStore._registered_attributes",
-            new=set(),
+            new=dict(),
         ):
             from footmav.data_definitions.base import NativeDataAttribute
             from footmav.data_definitions.data_sources import DataSource
@@ -146,7 +146,7 @@ class TestNativeDataAttribute:
     def test_user_transform_without_transform_function(self):
         with patch(
             "footmav.data_definitions.base.RegisteredAttributeStore._registered_attributes",
-            new=set(),
+            new=dict(),
         ):
             from footmav.data_definitions.base import NativeDataAttribute
             from footmav.data_definitions.data_sources import DataSource
@@ -168,7 +168,7 @@ class TestNativeDataAttribute:
     def test_pre_type_conversion_transform(self):
         with patch(
             "footmav.data_definitions.base.RegisteredAttributeStore._registered_attributes",
-            new=set(),
+            new=dict(),
         ):
             from footmav.data_definitions.base import NativeDataAttribute
             from footmav.data_definitions.data_sources import DataSource
@@ -189,7 +189,7 @@ class TestNativeDataAttribute:
     def test_post_type_conversion_transform(self):
         with patch(
             "footmav.data_definitions.base.RegisteredAttributeStore._registered_attributes",
-            new=set(),
+            new=dict(),
         ):
             from footmav.data_definitions.base import NativeDataAttribute
             from footmav.data_definitions.data_sources import DataSource
@@ -227,7 +227,7 @@ class TestNativeDataAttribute:
     ):
         with patch(
             "footmav.data_definitions.base.RegisteredAttributeStore._registered_attributes",
-            new=set(),
+            new=dict(),
         ):
             from footmav.data_definitions.base import NativeDataAttribute
             from footmav.data_definitions.data_sources import DataSource
@@ -258,7 +258,7 @@ class TestNumericDataAttribute:
     def test_init(self):
         with patch(
             "footmav.data_definitions.base.RegisteredAttributeStore._registered_attributes",
-            new=set(),
+            new=dict(),
         ):
             from footmav.data_definitions.base import NumericDataAttribute
             from footmav.data_definitions.data_sources import DataSource
@@ -278,7 +278,7 @@ class TestNumericDataAttribute:
     def test_pre_type_conversion_transform(self):
         with patch(
             "footmav.data_definitions.base.RegisteredAttributeStore._registered_attributes",
-            new=set(),
+            new=dict(),
         ):
             from footmav.data_definitions.base import NumericDataAttribute
             from footmav.data_definitions.data_sources import DataSource
@@ -298,7 +298,7 @@ class TestNumericDataAttribute:
     def test_post_type_conversion_transform(self):
         with patch(
             "footmav.data_definitions.base.RegisteredAttributeStore._registered_attributes",
-            new=set(),
+            new=dict(),
         ):
             from footmav.data_definitions.base import NumericDataAttribute
             from footmav.data_definitions.data_sources import DataSource
@@ -320,7 +320,7 @@ class TestFloatNumericDataAttribute:
     def test_init(self):
         with patch(
             "footmav.data_definitions.base.RegisteredAttributeStore._registered_attributes",
-            new=set(),
+            new=dict(),
         ):
             from footmav.data_definitions.base import FloatDataAttribute
             from footmav.data_definitions.data_sources import DataSource
@@ -341,7 +341,7 @@ class TestIntNumericDataAttribute:
     def test_init(self):
         with patch(
             "footmav.data_definitions.base.RegisteredAttributeStore._registered_attributes",
-            new=set(),
+            new=dict(),
         ):
             from footmav.data_definitions.base import IntDataAttribute
             from footmav.data_definitions.data_sources import DataSource
@@ -362,7 +362,7 @@ class TestStrNumericDataAttribute:
     def test_init(self):
         with patch(
             "footmav.data_definitions.base.RegisteredAttributeStore._registered_attributes",
-            new=set(),
+            new=dict(),
         ):
             from footmav.data_definitions.base import StrDataAttribute
             from footmav.data_definitions.data_sources import DataSource
@@ -383,7 +383,7 @@ class TestDateNumericDataAttribute:
     def test_init(self):
         with patch(
             "footmav.data_definitions.base.RegisteredAttributeStore._registered_attributes",
-            new=set(),
+            new=dict(),
         ):
             from footmav.data_definitions.base import DateDataAttribute
             from footmav.data_definitions.data_sources import DataSource

--- a/test/data_definitions/test_base.py
+++ b/test/data_definitions/test_base.py
@@ -39,7 +39,8 @@ class TestDataAttribute:
 
             f = MagicMock()
             with pytest.raises(
-                ValueError, match="DataAttribute with name test_name already exists"
+                ValueError,
+                match="Attribute test_name is already registered. Please use a different name.",
             ):
 
                 DataAttribute(
@@ -55,6 +56,46 @@ class TestDataAttribute:
                     f,
                     DataSource.FBREF,
                 )
+
+    def test_str(self):
+        with patch(
+            "footmav.data_definitions.base.RegisteredAttributeStore._registered_attributes",
+            new=dict(),
+        ):
+
+            from footmav.data_definitions.base import (
+                DataAttribute,
+            )
+            from footmav.data_definitions.data_sources import DataSource
+
+            f = MagicMock()
+            attr = DataAttribute(
+                "test_name",
+                "test_type",
+                f,
+                DataSource.FBREF,
+            )
+            assert str(attr) == "test_name"
+
+    def test_repr(self):
+        with patch(
+            "footmav.data_definitions.base.RegisteredAttributeStore._registered_attributes",
+            new=dict(),
+        ):
+
+            from footmav.data_definitions.base import (
+                DataAttribute,
+            )
+            from footmav.data_definitions.data_sources import DataSource
+
+            f = MagicMock()
+            attr = DataAttribute(
+                "test_name",
+                "test_type",
+                f,
+                DataSource.FBREF,
+            )
+            assert repr(attr) == "<DataAttribute(test_name)>"
 
 
 class TestNativeDataAttribute:

--- a/test/data_definitions/test_derived.py
+++ b/test/data_definitions/test_derived.py
@@ -22,7 +22,7 @@ class TestDerivedDataAttribute:
     ):
         with patch(
             "footmav.data_definitions.base.RegisteredAttributeStore._registered_attributes",
-            new=set(),
+            new=dict(),
         ):
             from footmav.data_definitions.data_sources import DataSource
 
@@ -45,7 +45,7 @@ class TestFunctionDerivedDataAttribute:
     def get_class(self):
         with patch(
             "footmav.data_definitions.base.RegisteredAttributeStore._registered_attributes",
-            new=set(),
+            new=dict(),
         ):
             from footmav.data_definitions.derived import FunctionDerivedDataAttribute
             from footmav.data_definitions.data_sources import DataSource
@@ -63,7 +63,7 @@ class TestFunctionDerivedDataAttribute:
     def test_init(self, get_class):
         with patch(
             "footmav.data_definitions.base.RegisteredAttributeStore._registered_attributes",
-            new=set(),
+            new=dict(),
         ):
             from footmav.data_definitions.data_sources import DataSource
 
@@ -78,7 +78,7 @@ class TestFunctionDerivedDataAttribute:
     def test_apply(self, get_class):
         with patch(
             "footmav.data_definitions.base.RegisteredAttributeStore._registered_attributes",
-            new=set(),
+            new=dict(),
         ):
             data_attribute, function = get_class
             result = data_attribute.apply(sentinel.data)

--- a/test/odm/test_fbref_data.py
+++ b/test/odm/test_fbref_data.py
@@ -3,11 +3,11 @@ from unittest.mock import MagicMock, patch, create_autospec, sentinel
 
 class TestFbRefData:
     @patch("footmav.odm.fbref_data.Data.__init__")
-    @patch("footmav.utils.cleanup.remove_non_top_5_teams")
+    @patch("footmav.odm.fbref_data.remove_non_top_5_teams")
     def test_init(self, remove_non_top_5_teams, super_init):
         with patch(
             "footmav.data_definitions.base.RegisteredAttributeStore._registered_attributes",
-            new=set(),
+            new=dict(),
         ):
             from footmav.odm.fbref_data import FbRefData
             from footmav.data_definitions.derived import DerivedDataAttribute
@@ -33,12 +33,8 @@ class TestFbRefData:
             attr4 = create_autospec(FloatDataAttribute)
             attr4.N = "attr4"
 
-            RegisteredAttributeStore._registered_attributes = {
-                attr1,
-                attr2,
-                attr3,
-                attr4,
-            }
+            for a in [attr1, attr2, attr3, attr4]:
+                RegisteredAttributeStore.register_attribute(a)
             data_with_duplicates_dropped = MagicMock()
             drop_duplicates_mock = MagicMock(return_value=data_with_duplicates_dropped)
             data_with_non_top_5_teams_removed = MagicMock(

--- a/test/operations/test_aggregations.py
+++ b/test/operations/test_aggregations.py
@@ -5,7 +5,7 @@ import pandas as pd
 def test_aggregate_by():
     with patch(
         "footmav.data_definitions.base.RegisteredAttributeStore._registered_attributes",
-        new=set(),
+        new=dict(),
     ):
         from footmav.operations.aggregations import aggregate_by
         from footmav.data_definitions.base import StrDataAttribute, FloatDataAttribute

--- a/test/operations/test_normalize.py
+++ b/test/operations/test_normalize.py
@@ -6,7 +6,7 @@ import pytest
 def test_per_90():
     with patch(
         "footmav.data_definitions.base.RegisteredAttributeStore._registered_attributes",
-        new=set(),
+        new=dict(),
     ):
         from footmav.operations.normalize import per_90
         from footmav.data_definitions.derived import FunctionDerivedDataAttribute
@@ -67,7 +67,7 @@ def test_per_90():
 def test_per_90_no_mins():
     with patch(
         "footmav.data_definitions.base.RegisteredAttributeStore._registered_attributes",
-        new=set(),
+        new=dict(),
     ):
         from footmav.operations.normalize import per_90
 


### PR DESCRIPTION
This is to avoid derived attributes being calculated out of order and using
non existent columns.  this is a temporary measure.  The real solution
is to implement calculation cascading or explicit dependencies